### PR TITLE
Fix to ValueError: insecure string pickle

### DIFF
--- a/tools/email_preprocess.py
+++ b/tools/email_preprocess.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import pickle
+import cPickle
 import numpy
 
 from sklearn import cross_validation
@@ -28,8 +29,13 @@ def preprocess(words_file = "../tools/word_data.pkl", authors_file="../tools/ema
 
     ### the words (features) and authors (labels), already largely preprocessed
     ### this preprocessing will be repeated in the text learning mini-project
-    word_data = pickle.load( open(words_file, "r"))
-    authors = pickle.load( open(authors_file, "r") )
+    authors_file_handler = open(authors_file, "r")
+    authors = pickle.load(authors_file_handler)
+    authors_file_handler.close()
+
+    words_file_handler = open(words_file, "r")
+    word_data = cPickle.load(words_file_handler)
+    words_file_handler.close()
 
     ### test_size is the percentage of events assigned to the test set (remainder go into training)
     features_train, features_test, labels_train, labels_test = cross_validation.train_test_split(word_data, authors, test_size=0.1, random_state=42)
@@ -54,6 +60,5 @@ def preprocess(words_file = "../tools/word_data.pkl", authors_file="../tools/ema
     ### info on the data
     print "no. of Chris training emails:", sum(labels_train)
     print "no. of Sara training emails:", len(labels_train)-sum(labels_train)
-
-
+    
     return features_train_transformed, features_test_transformed, labels_train, labels_test


### PR DESCRIPTION
In my machine, existing code caused error ValueError: insecure string pickle. This was caused by the size of words_file.

To fix this, I use C++ implementation of pickle called cPickle.

I hope this helps other students.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/ud120-projects/16)
<!-- Reviewable:end -->
