### PR TITLE
Check if scipy is installed in startup.py

### DIFF
--- a/tools/startup.py
+++ b/tools/startup.py
@@ -13,6 +13,12 @@ try:
 except ImportError:
     print "you should install numpy before continuing"
 
+print "checking for scipy"
+try:
+    import scipy
+except:
+    print "you should install scipy before continuing"
+
 print "checking for sklearn"
 try:
     import sklearn


### PR DESCRIPTION
scipy is a prerequisite of sklearn, so it needs to be installed as well.  Without this change, an `ImportError` will be thrown by `import sklearn` even if sklearn is installed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/ud120-projects/18)
<!-- Reviewable:end -->
