### PR TITLE
Multiple fixes/reorg

### DIFF
--- a/tools/startup.py
+++ b/tools/startup.py
@@ -8,22 +8,22 @@ from urllib import urlretrieve
 realpath = os.path.dirname(os.path.realpath(__file__))
 
 print("")
-print("checking for nltk")
 try:
+    print("checking for nltk")
     import nltk
 except ImportError:
     print("you should install nltk before continuing")
     exit()
 
-print("checking for numpy")
 try:
+    print("checking for numpy")
     import numpy
 except ImportError:
     print "you should install numpy before continuing"
     exit()
 
-print("checking for sklearn")
 try:
+    print("checking for sklearn")
     import sklearn
 except ImportError:
     print "you should install sklearn before continuing"

--- a/tools/startup.py
+++ b/tools/startup.py
@@ -1,41 +1,66 @@
 #!/usr/bin/python
 
-print
-print "checking for nltk"
+import os
+from tarfile import open
+from urllib import urlretrieve
+
+
+realpath = os.path.dirname(os.path.realpath(__file__))
+
+print("")
+print("checking for nltk")
 try:
     import nltk
 except ImportError:
-    print "you should install nltk before continuing"
+    print("you should install nltk before continuing")
+    exit()
 
-print "checking for numpy"
+print("checking for numpy")
 try:
     import numpy
 except ImportError:
     print "you should install numpy before continuing"
+    exit()
 
-print "checking for sklearn"
+print("checking for sklearn")
 try:
     import sklearn
-except:
+except ImportError:
     print "you should install sklearn before continuing"
+    exit()
 
-print
-print "downloading the Enron dataset (this may take a while)"
-print "to check on progress, you can cd up one level, then execute <ls -lthr>"
-print "Enron dataset should be last item on the list, along with its current size"
-print "download will complete at about 423 MB"
-import urllib
-url = "https://www.cs.cmu.edu/~./enron/enron_mail_20150507.tgz"
-urllib.urlretrieve(url, filename="../enron_mail_20150507.tgz") 
-print "download complete!"
+tar_exists = False
 
+try:
+    tar_exists = os.path.isfile(realpath + "/../enron_mail_20150507.tgz")
+except IOError:
+    pass
 
-print
-print "unzipping Enron dataset (this may take a while)"
-import tarfile
-import os
-os.chdir("..")
-tfile = tarfile.open("enron_mail_20150507.tgz", "r:gz")
-tfile.extractall(".")
+if tar_exists:
+    print("you already have the Enron tarball")
+    print("if you would like a new version, please remove the tarball and run this script again")
+else:
+    print("")
+    print("downloading the Enron dataset (this may take a while)")
+    print("to check on progress, execute <ls -lthr " + realpath + "/..>")
+    print("Enron dataset should be last item on the list, along with its current size")
+    print("download will complete at about 423 MB")
+    url = "https://www.cs.cmu.edu/~./enron/enron_mail_20150507.tgz"
+    urlretrieve(url, filename=realpath+"/../enron_mail_20150507.tgz")
+    print("download complete!")
 
-print "you're ready to go!"
+try:
+    maildir_exists = os.path.isdir(realpath + "/../maildir")
+except IOError:
+    pass
+
+if maildir_exists:
+    print("you already have the unzipped Enron emails. Check maildir")
+    print("if you would like a new version, please remove the maildir directory and run this script again")
+else:
+    print("")
+    print("unzipping Enron dataset (this may take a while)")
+    tfile = open(realpath + "/../enron_mail_20150507.tgz", "r:gz")
+    tfile.extractall(realpath+"/..")
+
+print("you're ready to go!")


### PR DESCRIPTION
Added multiple fixes for the script:
- `startup.py` (not necessarily libraries) works with Python 3.
- Can call `startup.py` from anywhere and Enron data is always put in the project root.
- Script exits if libraries aren't installed.
- Enron data won't be downloaded if it already exists in project root (unless user deletes old tarball).
- Enron data won't be extracted if the `maildir` directory already exists in project root (unless user deletes old directory).
- Only import methods that are used.
- Reorganization.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/ud120-projects/19)

<!-- Reviewable:end -->
