### PR TITLE
Added option to read binary

### DIFF
--- a/datasets_questions/explore_enron_data.py
+++ b/datasets_questions/explore_enron_data.py
@@ -17,6 +17,6 @@
 
 import pickle
 
-enron_data = pickle.load(open("../final_project/final_project_dataset.pkl", "r"))
+enron_data = pickle.load(open("../final_project/final_project_dataset.pkl", "rb"))
 
 


### PR DESCRIPTION
Python2 throws no errors for a missing binary flag, but Py3 does. This code now works on both versions.
