### PR TITLE
Fix choose_your_own rendering

### DIFF
--- a/choose_your_own/your_algorithm.py
+++ b/choose_your_own/your_algorithm.py
@@ -24,7 +24,6 @@ plt.scatter(grade_slow, bumpy_slow, color = "r", label="slow")
 plt.legend()
 plt.xlabel("bumpiness")
 plt.ylabel("grade")
-plt.show()
 ################################################################################
 
 
@@ -42,3 +41,5 @@ try:
     prettyPicture(clf, features_test, labels_test)
 except NameError:
     pass
+
+plt.show()


### PR DESCRIPTION
I'm not 100% sure why, but when I run the code without this change, I see only the blue and red points in the visualization, like so:

![before](https://cloud.githubusercontent.com/assets/114976/18641571/384020e0-7e6b-11e6-9b33-e32c0016322a.png)

It doesn't include the coloring of the background to indicate which class my algorithm would assign to an arbitrary point. 

With this change, it renders as expected:

![after](https://cloud.githubusercontent.com/assets/114976/18641590/4fbf06f0-7e6b-11e6-8b03-8c9e7498da9e.png)

My best guess is that `plt.show()` is a blocking method, so it prevents the user's classifier from running until they close the popup.. at which point they cannot see the results. This change waits until everything is calculated before calling `plt.show()`, and seems to work correctly.

Note: you'll also have to complete the "your code here"  section to get the expected example. Otherwise it always render like the "before" image. This is the code I have:

```py
from sklearn.neighbors import KNeighborsClassifier
from sklearn.metrics import accuracy_score
from time import time

clf = KNeighborsClassifier()

t0 = time()
clf.fit(features_train, labels_train)
print "training time:", round(time()-t0, 3), "s"

t0 = time()
pred = clf.predict(features_test)
print "prediction time:", round(time()-t0, 3), "s"

score = accuracy_score(labels_test, pred)
print "accuracy:", round(score, 3)
```