### PR TITLE
Updates test_color on finance_regression.py

### DIFF
--- a/regression/finance_regression.py
+++ b/regression/finance_regression.py
@@ -29,7 +29,7 @@ target, features = targetFeatureSplit( data )
 from sklearn.cross_validation import train_test_split
 feature_train, feature_test, target_train, target_test = train_test_split(features, target, test_size=0.5, random_state=42)
 train_color = "b"
-test_color = "b"
+test_color = "r"
 
 
 


### PR DESCRIPTION
- I'm curious why there's a comment about changing the `test_color` variable rather than just having it be `'r'` in the first place.