### PR TITLE
Close tarfile after extraction

### DIFF
--- a/tools/startup.py
+++ b/tools/startup.py
@@ -1,47 +1,47 @@
 #!/usr/bin/python
 
-print
-print "checking for nltk"
+import os
+import tarfile
+import urllib
+
+print("\nchecking for nltk")
 try:
     import nltk
 except ImportError:
-    print "you should install nltk before continuing"
+    print("you should install nltk before continuing")
 
-print "checking for numpy"
+print("checking for numpy")
 try:
     import numpy
 except ImportError:
-    print "you should install numpy before continuing"
+    print("you should install numpy before continuing")
 
-print "checking for scipy"
+print("checking for scipy")
 try:
     import scipy
 except:
-    print "you should install scipy before continuing"
+    print("you should install scipy before continuing")
 
-print "checking for sklearn"
+print("checking for sklearn")
 try:
     import sklearn
 except:
-    print "you should install sklearn before continuing"
+    print("you should install sklearn before continuing")
 
-print
-print "downloading the Enron dataset (this may take a while)"
-print "to check on progress, you can cd up one level, then execute <ls -lthr>"
-print "Enron dataset should be last item on the list, along with its current size"
-print "download will complete at about 423 MB"
-import urllib
+print("""\ndownloading the Enron dataset (this may take a while)
+to check on progress, you can cd up one level, then execute <ls -lthr>
+Enron dataset should be last item on the list, along with its current size
+download will complete at about 423 MB""")
+
 url = "https://www.cs.cmu.edu/~./enron/enron_mail_20150507.tgz"
 urllib.urlretrieve(url, filename="../enron_mail_20150507.tgz") 
-print "download complete!"
+print("download complete!")
 
+print("\nunzipping Enron dataset (this may take a while)")
 
-print
-print "unzipping Enron dataset (this may take a while)"
-import tarfile
-import os
 os.chdir("..")
-tfile = tarfile.open("enron_mail_20150507.tgz", "r:gz")
+tfile = tarfile.open("enron_mail_20150507.tgz", mode="r:gz")
 tfile.extractall(".")
+tfile.close()
 
-print "you're ready to go!"
+print("you're ready to go!")


### PR DESCRIPTION
It's generally not good practice to rely on garbage collection to close open files, so we should call close() after extraction. I also removed the blank print lines and instead use the newline character "\n" for cleaner code. Finally, print is called as a function for Python 3.x forwards compatibility.