### PR TITLE
Show a progress percentage while downloading Enron dataset.

### DIFF
--- a/tools/startup.py
+++ b/tools/startup.py
@@ -1,5 +1,32 @@
 #!/usr/bin/python
 
+from sys import stdout
+
+def reporthook(download_description):
+    """Build a reporthook for retrieving with urllib.
+
+    Args:
+        download_description (str): a description of the download
+        that will be displayed at any downloaded HTTP chunk.
+    """
+    spinner_frames = ['|', '/', '-', '\\']
+
+    def hook(chunk_number, chunk_size, download_size):
+        if chunk_size < download_size:
+            hook.received_size += chunk_size
+        else:
+            hook.received_size = download_size
+
+        progress_percentage = int(100*hook.received_size/download_size)
+        spinner_frame = spinner_frames[chunk_number % len(spinner_frames)]
+
+        stdout.write("downloading {} ({}MB): {:2d}% {}\r".format(
+            download_description, int(download_size/1e6), progress_percentage, spinner_frame))
+        stdout.flush()
+
+    hook.received_size = 0
+    return hook
+
 print
 print "checking for nltk"
 try:
@@ -26,15 +53,11 @@ except:
     print "you should install sklearn before continuing"
 
 print
-print "downloading the Enron dataset (this may take a while)"
-print "to check on progress, you can cd up one level, then execute <ls -lthr>"
-print "Enron dataset should be last item on the list, along with its current size"
-print "download will complete at about 423 MB"
 import urllib
 url = "https://www.cs.cmu.edu/~./enron/enron_mail_20150507.tgz"
-urllib.urlretrieve(url, filename="../enron_mail_20150507.tgz") 
-print "download complete!"
-
+urllib.urlretrieve(url, filename="../enron_mail_20150507.tgz", reporthook=reporthook("Enron dataset"))
+print
+print "download complete"
 
 print
 print "unzipping Enron dataset (this may take a while)"


### PR DESCRIPTION
[`urllib.urlretrieve()`](https://docs.python.org/2/library/urllib.html#urllib.urlretrieve) expose an hook that's called
whenever an HTTP chunk has been fetched from
the network. This is used to compute the current
progress of the download.