### PR TITLE
use pickle instead of cPickle

### DIFF
--- a/tools/email_preprocess.py
+++ b/tools/email_preprocess.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 
 import pickle
-import cPickle
 import numpy
-
 from sklearn import cross_validation
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.feature_selection import SelectPercentile, f_classif
@@ -34,7 +32,7 @@ def preprocess(words_file = "../tools/word_data.pkl", authors_file="../tools/ema
     authors_file_handler.close()
 
     words_file_handler = open(words_file, "r")
-    word_data = cPickle.load(words_file_handler)
+    word_data = pickle.load(words_file_handler)
     words_file_handler.close()
 
     ### test_size is the percentage of events assigned to the test set


### PR DESCRIPTION
on my macbook with 16G and 4core i7 CPU, runing python 2.7.13 with virutalEnv, the cPickle version takes about 4.2 seconds and pickle version takes about 3.1 seconds.