### PR TITLE
Get rid of 'DIGITAL Command Language' on GH

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.com linguist-language=Text


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5220825/30526601-41af464c-9c15-11e7-9e3c-ce678ee4d4a7.png)

Don't use the data files (*.com) count as code.
The project will seen on GH as 100% Python as it really is.