### PR TITLE
Added matplotlib.pylab to the import

### DIFF
--- a/pca/eigenfaces.py
+++ b/pca/eigenfaces.py
@@ -20,7 +20,7 @@ print __doc__
 
 from time import time
 import logging
-import pylab as pl
+import matplotlib.pylab as pl
 import numpy as np
 
 from sklearn.cross_validation import train_test_split


### PR DESCRIPTION
Added "import matplotlib.pylab as pl" because "import pylab as pl" is giving some errors.
