### PR TITLE
close the plt figure

### DIFF
--- a/choose_your_own/class_vis.py
+++ b/choose_your_own/class_vis.py
@@ -34,6 +34,7 @@ def prettyPicture(clf, X_test, y_test):
     plt.ylabel("grade")
 
     plt.savefig("test.png")
+    plt.close()
 
 import base64
 import json


### PR DESCRIPTION
Close the figure after plotting to prevent incorrect figures when saving multiples plots