### PR TITLE
Python 3 compatibility

### DIFF
--- a/choose_your_own/class_vis.py
+++ b/choose_your_own/class_vis.py
@@ -46,5 +46,5 @@ def output_image(name, format, bytes):
     data['name'] = name
     data['format'] = format
     data['bytes'] = base64.encodestring(bytes)
-    print image_start+json.dumps(data)+image_end
+    print (image_start+json.dumps(data)+image_end)
                                     


### PR DESCRIPTION
Print statement changed to print function in python 3, so it requires parentheses.
https://stackoverflow.com/questions/937491/invalid-syntax-when-using-print