### PR TITLE
Bug fix in pickle load

### DIFF
--- a/datasets_questions/explore_enron_data.py
+++ b/datasets_questions/explore_enron_data.py
@@ -17,6 +17,6 @@
 
 import pickle
 
-enron_data = pickle.load(open("../final_project/final_project_dataset.pkl", "r"))
+enron_data = pickle.load(open("../final_project/final_project_dataset.pkl", "rb"))
 
 


### PR DESCRIPTION
Avoid error: TypeError: a bytes-like object is required, not 'str'
by changing 'r' to 'rb' read mode.
https://stackoverflow.com/questions/33054527/python-3-5-typeerror-a-bytes-like-object-is-required-not-str-when-writing-t