### PR TITLE
Workaround for SSLError while downloaidng dataset

### DIFF
--- a/tools/startup.py
+++ b/tools/startup.py
@@ -32,7 +32,22 @@ print "Enron dataset should be last item on the list, along with its current siz
 print "download will complete at about 423 MB"
 import urllib
 url = "https://www.cs.cmu.edu/~./enron/enron_mail_20150507.tar.gz"
-urllib.urlretrieve(url, filename="../enron_mail_20150507.tar.gz") 
+filename = "../enron_mail_20150507.tar.gz"
+try: 
+    urllib.urlretrieve(url, filename=filename)
+except IOError as socket_error:
+    expected_error = (
+        "IOError('socket error', SSLError(1, u'[SSL: DH_KEY_TOO_SMALL]"+
+        " dh key too small (_ssl.c:727)'))"
+        )
+    if repr(socket_error) == expected_error:
+        import ssl
+        cipher = "ECDHE-RSA-AES128-GCM-SHA256"
+        context = ssl.create_default_context()
+        context.set_ciphers(cipher)
+        urllib.urlretrieve(url, filename=filename, context=context)
+    else:
+        raise socket_error
 print "download complete!"
 
 


### PR DESCRIPTION
Workaround for weak DH key used by www.cs.cmu.edu. Cipher selected is supported by server and is known to have no security flaw. Workaround code is only run when user encounter error on system as it is possible that older systems do not raise warning but may not support workaround cipher. Throwback error if its not exactly what we are looking for, to prevent hiding any other possible bug.