### PR TITLE
Update eigenfaces.py

### DIFF
--- a/pca/eigenfaces.py
+++ b/pca/eigenfaces.py
@@ -23,12 +23,11 @@ import logging
 import pylab as pl
 import numpy as np
 
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import train_test_split, GridSearchCV
 from sklearn.datasets import fetch_lfw_people
-from sklearn.grid_search import GridSearchCV
 from sklearn.metrics import classification_report
 from sklearn.metrics import confusion_matrix
-from sklearn.decomposition import RandomizedPCA
+from sklearn.decomposition import PCA
 from sklearn.svm import SVC
 
 # Display progress logs on stdout
@@ -69,7 +68,7 @@ n_components = 150
 
 print("Extracting the top %d eigenfaces from %d faces" % (n_components, X_train.shape[0]))
 t0 = time()
-pca = RandomizedPCA(n_components=n_components, whiten=True).fit(X_train)
+pca = PCA(n_components=n_components, whiten=True).fit(X_train)
 print("done in %0.3fs" % (time() - t0))
 
 eigenfaces = pca.components_.reshape((n_components, h, w))


### PR DESCRIPTION
Renamed RandomizedPCA to PCA as it has been deprecated in sklearn current version and changed import GridSearchCV from model selection rather from grid_search.