### PR TITLE
Fixed path for practice_outliers

### DIFF
--- a/outliers/outlier_removal_regression.py
+++ b/outliers/outlier_removal_regression.py
@@ -9,8 +9,8 @@ from outlier_cleaner import outlierCleaner
 
 
 ### load up some practice data with outliers in it
-ages = joblib.load( open("practice_outliers_ages.pkl", "rb") )
-net_worths = joblib.load( open("practice_outliers_net_worths.pkl", "rb") )
+ages = joblib.load( open("./outliers/practice_outliers_ages.pkl", "rb") )
+net_worths = joblib.load( open("./outliers/practice_outliers_net_worths.pkl", "rb") )
 
 
 


### PR DESCRIPTION
The path was showing error for 'ages' and 'net_worth' both while loading it so I fixed the path issue.

ages = joblib.load( open("practice_outliers_ages.pkl", "rb") )
FileNotFoundError: [Errno 2] No such file or directory: 'practice_outliers_ages.pkl'