### PR TITLE
Add venv contents to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ my_dataset.pkl
 my_feature_list.pkl
 .DS_Store
 __pycache__
+venv/


### PR DESCRIPTION
Adding `venv/` to `gitignore` allows users to create virtual environments without having to commit any of the contents to GitHub.