### PR TITLE
Fix reduction of training data

### DIFF
--- a/svm/svm_author_id.py
+++ b/svm/svm_author_id.py
@@ -27,13 +27,3 @@ features_train, features_test, labels_train, labels_test = preprocess()
 #########################################################
 
 #########################################################
-'''
-You'll be Provided similar code in the Quiz
-But the Code provided in Quiz has an Indexing issue
-The Code Below solves that issue, So use this one
-'''
-
-# features_train = features_train[:int(len(features_train)/100)]
-# labels_train = labels_train[:int(len(labels_train)/100)]
-
-#########################################################


### PR DESCRIPTION
The reduction of the amount of training data is not required for "SVM Author ID Accuracy". It should be manually added by the students in "A Smaller Training Set". The decrease in amount of training data leads to low accuracy not accepted by the quiz in "SVM Author ID Accuracy"